### PR TITLE
switch to mocha, expect, zuul and phantom - switch to memdown - closes #1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,10 @@ language: node_js
 node_js:
   - '0.10'
   - '0.12'
+# https://mediocre.com/forum/topics/phantomjs-2-and-travis-ci-we-beat-our-heads-against-a-wall-so-you-dont-have-to
+# we alter PATH to use PWD first to avoid the use of sudo
+before_install:
+  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+  - tar -xjf phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+  - export PATH=$PWD:$PATH
+script: npm run ci

--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,0 +1,1 @@
+ui: mocha-bdd

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 'use strict';
 
 var levelup = require('levelup');
-var leveldown = require('leveldown');
+var memdown = require('memdown');
 var Immstruct = require('immstruct').Immstruct;
 
-var db = levelup('snacks', { db: leveldown, valueEncoding: 'json' });
+var db = levelup('snacks', { db: memdown, valueEncoding: 'json' });
 
 function snacks(app, opts, cb){
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Irken plugin exposing configuration options",
   "main": "index.js",
   "scripts": {
-    "test": "lab -cv"
+    "test": "zuul test/ --local --open",
+    "ci": "zuul test/ --phantom"
   },
   "repository": {
     "type": "git",
@@ -23,16 +24,18 @@
   },
   "homepage": "https://github.com/iceddev/snacks",
   "devDependencies": {
-    "code": "^1.3.0",
+    "expect": "^1.6.0",
     "irken": "^0.3.0",
-    "lab": "^5.4.0"
+    "mocha": "^2.2.1",
+    "phantomjs": "git://github.com/phated/phantomjs",
+    "zuul": "^2.1.1"
   },
   "peerDependencies": {
     "irken": ">=0.3.0"
   },
   "dependencies": {
     "immstruct": "^1.4.0",
-    "leveldown": "^0.10.4",
-    "levelup": "^0.19.0"
+    "levelup": "^0.19.0",
+    "memdown": "^1.0.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,72 +1,71 @@
 'use strict';
 
-var lab = exports.lab = require('lab').script();
-var code = require('code');
+var expect = require('expect');
 
 var Irken = require('irken');
 
 var snacks = require('../');
 
-lab.experiment('snacks', function(){
+describe('snacks', function(){
 
   var app;
 
-  lab.beforeEach(function(done){
+  beforeEach(function(done){
     app = new Irken();
     done();
   });
 
-  lab.test('exposes a cusor as `userConfig` on the application', function(done){
+  it('exposes a cusor as `userConfig` on the application', function(done){
     app.register(snacks, function(err){
-      code.expect(err).to.not.exist();
-      code.expect(app.userConfig).to.exist();
-      code.expect(app.userConfig.deref).to.be.a.function();
+      expect(err).toNotExist();
+      expect(app.userConfig).toExist();
+      expect(app.userConfig.deref).toBeA(Function);
       done(err);
     });
   });
 
-  lab.test('allows a custom namespace', function(done){
+  it('allows a custom namespace', function(done){
     var plugin = {
       register: snacks,
       options: { namespace: 'config' }
     };
     app.register(plugin, function(err){
-      code.expect(err).to.not.exist();
-      code.expect(app.config).to.exist();
-      code.expect(app.config.deref).to.be.a.function();
+      expect(err).toNotExist();
+      expect(app.config).toExist();
+      expect(app.config.deref).toBeA(Function);
       done(err);
     });
   });
 
-  lab.test('updates the cursor upon change', function(done){
+  it('updates the cursor upon change', function(done){
     app.register(snacks, function(err){
-      code.expect(err).to.not.exist();
+      expect(err).toNotExist();
 
       app.userConfig.set('test', 1234);
 
-      code.expect(app.userConfig.get('test')).to.exist();
-      code.expect(app.userConfig.get('test')).to.equal(1234);
+      expect(app.userConfig.get('test')).toExist();
+      expect(app.userConfig.get('test')).toEqual(1234);
       done(err);
     });
   });
 
-  lab.test('populates the cursor with previously saved props', function(done){
+  it('populates the cursor with previously saved props', function(done){
     app.register(snacks, function(err){
-      code.expect(err).to.not.exist();
-      code.expect(app.userConfig.get('test')).to.exist();
-      code.expect(app.userConfig.get('test')).to.equal(1234);
+      expect(err).toNotExist();
+      expect(app.userConfig.get('test')).toExist();
+      expect(app.userConfig.get('test')).toEqual(1234);
       done(err);
     });
   });
 
-  lab.test('overwrites already set values', function(done){
+  it('overwrites already set values', function(done){
     app.register(snacks, function(err){
-      code.expect(err).to.not.exist();
+      expect(err).toNotExist();
 
       app.userConfig.set('test', 'hello');
 
-      code.expect(app.userConfig.get('test')).to.exist();
-      code.expect(app.userConfig.get('test')).to.equal('hello');
+      expect(app.userConfig.get('test')).toExist();
+      expect(app.userConfig.get('test')).toEqual('hello');
       done(err);
     });
   });


### PR DESCRIPTION
These are meant to run in the browser, so I switched the tests over to browser only, even though they run in node.  Also removed leveldown for memdown because it achieves the same thing without the native dep.
